### PR TITLE
Add jsonx as an OTP dependency

### DIFF
--- a/src/jsn.app.src
+++ b/src/jsn.app.src
@@ -9,6 +9,7 @@
     {description, "Utilities for interacting with decoded JSON in erlang"},
     {vsn, git},
     {applications, [kernel,
-                    stdlib]}
+                    stdlib,
+                    jsonx]}
  ]}.
 % vim:ft=erlang


### PR DESCRIPTION
Although encode/decode are deprecated by #5, it is necessary for jsonx to be explicitly noted in the `applications` section of the OTP application file in order for rebar3 to include its code when generating releases.