### PR TITLE
Add rebar.config.script with rebar 2.x compatibility

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,7 @@
+case erlang:function_exported(rebar3, main, 1) of
+    true -> % rebar3
+        CONFIG;
+    false -> % rebar 2.x or older
+        NewDeps = {deps, [{jsonx, "", {git, "https://github.com/alertlogic/jsonx.git", {branch, master}}}]},
+        lists:keyreplace(deps, 1, CONFIG, NewDeps)
+end.


### PR DESCRIPTION
I noticed that the rebar3 update wasn't compatible with rebar 2.x because of the deps format change.

That won't matter in the v2.x.x release  when encoding/decoding support is removed and "left as an exercise for the reader" (as the deps will be `[]`), but for the sake of the 1.1.x branch supporting legacy Erlang for those that need it, this seems worth retaining.