### PR TITLE
implements select()

### DIFF
--- a/include/jsn.hrl
+++ b/include/jsn.hrl
@@ -70,6 +70,18 @@
 -type path_element() ::  binary() | json_array_index().
 -type path_elements() :: [ path_element() ].
 
+%% Select conditions
+%%
+%% Select conditions are passed to the select/2 function for filtering
+%% lists of jsn objects
+
+-type value_selection() :: {value, path()} | {value, path(), Default :: term()}.
+-type selection() :: identity | value_selection() | [value_selection()].
+-type condition() :: {path(), Value :: json_term()} | %% exact match syntactic sugar
+                     {path(), fun((Value :: json_term()) -> boolean())} | %% boolean function with input of the value at the path
+                     fun((Element :: json_term()) -> boolean()). %% boolean function that takes a whole array element
+-type conditions() :: [condition()].
+
 %%=============================================================================
 %% jsn constants
 %%=============================================================================

--- a/include/jsn.hrl
+++ b/include/jsn.hrl
@@ -70,16 +70,15 @@
 -type path_element() ::  binary() | json_array_index().
 -type path_elements() :: [ path_element() ].
 
-%% Select conditions
+%% Select types
 %%
-%% Select conditions are passed to the select/2 function for filtering
-%% lists of jsn objects
+%% Select types are passed to the select function for filtering and mapping
 
--type value_selection() :: {value, path()} | {value, path(), Default :: term()}.
--type selection() :: identity | value_selection() | [value_selection()].
--type condition() :: {path(), Value :: json_term()} | %% exact match syntactic sugar
-                     {path(), fun((Value :: json_term()) -> boolean())} | %% boolean function with input of the value at the path
-                     fun((Element :: json_term()) -> boolean()). %% boolean function that takes a whole array element
+-type selection()  :: identity | {value, path()} | {value, path(), Default :: term()}.
+-type selections() :: [selection()].
+-type condition()  :: {path(), Value :: json_term()} | %% exact match syntactic sugar
+                      {path(), fun((Value :: json_term()) -> boolean())} | %% boolean function with input of the value at the path
+                      fun((Element :: json_term()) -> boolean()). %% boolean function that takes a whole array element
 -type conditions() :: [condition()].
 
 %%=============================================================================

--- a/src/jsn.erl
+++ b/src/jsn.erl
@@ -177,11 +177,8 @@ find(Path, Subpath, SearchTerm, Object) ->
 %%------------------------------------------------------------------------------
 %% @doc Transforms a list of Elements according to a given Selectionification
 %%------------------------------------------------------------------------------
-select(Selection, Elements) when is_list(Elements) ->
-    select(Selection, [], Elements);
-select(_Selection, _Elements) ->
-    erlang:error(badarg).
-
+select(Selection, Elements) ->
+    select(Selection, [], Elements).
 
 -spec select(selection()|selections(),
              condition()|conditions(),
@@ -199,8 +196,8 @@ select(Selection, Condition, Elements) when is_list(Elements) ->
                 false
         end
     end, Elements);
-select(_Selection, _Conditions, _Elements) ->
-    erlang:error(badarg).
+select(Selection, Conditions, Elements) ->
+    erlang:error(badarg, [Selection, Conditions, Elements]).
 
 
 -spec set(path(), json_object(), Value :: json_term()) -> json_object();
@@ -707,8 +704,8 @@ apply_condition({Path, Value}, Element) ->
     get(Path, Element) == Value;
 apply_condition(ConditionFun, Element) when is_function(ConditionFun, 1) ->
     ConditionFun(Element);
-apply_condition(_, _) ->
-    erlang:error(invalid_condition).
+apply_condition(Condition, Element) ->
+    erlang:error(badarg, [Condition, Element]).
 
 
 -spec apply_selections(selections(), json_term()) -> term().
@@ -724,8 +721,8 @@ apply_selection({value, Path}, Element) ->
     get(Path, Element);
 apply_selection({value, Path, Default}, Element) ->
     get(Path, Element, Default);
-apply_selection(_, _) ->
-    erlang:error(invalid_selection).
+apply_selection(Selection, Element) ->
+    erlang:error(badarg, [Selection, Element]).
 
 
 -spec get_format(jsn_options()) -> format().

--- a/test/jsn_tests.erl
+++ b/test/jsn_tests.erl
@@ -522,7 +522,11 @@ select_test_() ->
      ?_assertEqual([<<"No Name">>],
                    jsn:select({value, <<"username">>, <<"No Name">>},
                               [{<<"username">>, undefined}],
-                              Objects))
+                              Objects)),
+     ?_assertError(invalid_selection,
+                   jsn:select(random_invalid_selection, [{<<"username">>, undefined}], Objects)),
+     ?_assertError(invalid_condition,
+                   jsn:select({value, <<"username">>, <<"No Name">>}, random_invalid_condition, Objects))
     ].
 
 

--- a/test/jsn_tests.erl
+++ b/test/jsn_tests.erl
@@ -523,9 +523,9 @@ select_test_() ->
                    jsn:select({value, <<"username">>, <<"No Name">>},
                               [{<<"username">>, undefined}],
                               Objects)),
-     ?_assertError(invalid_selection,
+     ?_assertError(badarg,
                    jsn:select(random_invalid_selection, [{<<"username">>, undefined}], Objects)),
-     ?_assertError(invalid_condition,
+     ?_assertError(badarg,
                    jsn:select({value, <<"username">>, <<"No Name">>}, random_invalid_condition, Objects))
     ].
 

--- a/test/jsn_tests.erl
+++ b/test/jsn_tests.erl
@@ -499,6 +499,32 @@ path_elements_test_() ->
      ?_assertError(badarg, jsn:path_elements(0)),
      ?_assertError(badarg, jsn:path_elements([10, <<"foo">>]))].
 
+select_test_() ->
+    Alice = jsn:new([{<<"username">>, <<"Alice">>}, {<<"created.by">>, <<"Dana">>},     {<<"created.at">>, 1503702360}]),
+    Bob   = jsn:new([{<<"username">>, <<"Bob">>},   {<<"created.by">>, <<"Eve">>},      {<<"created.at">>, 1503702417}]),
+    Carl  = jsn:new([{<<"username">>, <<"Carl">>},  {<<"created.by">>, <<"Frank">>},    {<<"created.at">>, 1503702417}]),
+    None  = jsn:new([                               {<<"created.by">>, <<"Gretchen">>}, {<<"created.at">>, 1503704439}]),
+    Objects = [Alice, Bob, Carl, None],
+    [?_assertEqual([<<"Alice">>, <<"Bob">>, <<"Carl">>, undefined],
+                   jsn:select({value, <<"username">>}, Objects)),
+     ?_assertEqual([<<"Alice">>],
+                   jsn:select({value, <<"username">>},
+                              [{<<"created.at">>, fun(V) -> V < 1503702416 end},
+                               fun(E) -> jsn:get(<<"created.by">>, E) == <<"Dana">> end],
+                              Objects)),
+     ?_assertEqual([[<<"Bob">>, <<"Eve">>], [<<"Carl">>, <<"Frank">>]],
+                   jsn:select([{value, <<"username">>, <<"No Name">>},
+                               {value, {<<"created">>, <<"by">>}}],
+                              [{<<"created.at">>, 1503702417}],
+                              Objects)),
+     ?_assertEqual([None],
+                   jsn:select(identity, [{<<"username">>, undefined}], Objects)),
+     ?_assertEqual([<<"No Name">>],
+                   jsn:select({value, <<"username">>, <<"No Name">>},
+                              [{<<"username">>, undefined}],
+                              Objects))
+    ].
+
 
 sort_test_() ->
     Proplist = [{c, [{z, 1},{x, 2}]},


### PR DESCRIPTION
Initial implementation of select() according to https://github.com/nalundgaard/jsn/issues/10

This implementation uses a few anonymous functions but I'm not sure you guys like this syntax. I could change it to private functions instead or just pass the functions directly to the lists:*

Additionally, I'm not 100% ok with the documentation I added but also I'm not sure I should explain all the input options here or should we just leave it to the user to go to jsn.hrl and figure it out by himself