### PR TITLE
Introduce version 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ otp_release:
   - 20.1
   - 19.3
   - 18.3
-  - 17.5
-  - R16B03-1
 install: true
 script:
   - ./rebar3 compile 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ JSON objects in particular.
 
 In the spirit of [ej][ej], it supports the common formats output by JSON
 decoders such as [jsone][jsone], [jiffy][jiffy], and [mochijson2][mochijson2].
-Unlike [ej][ej], however, it supports _all three_ common JSON representations
+Unlike [ej][ej], however, it supports _all four_ common JSON representations
 in Erlang:
 
-* `proplist` (**default**)(used by [jsonx][jsonx])
-* `map` (common to [jsone][jsone], [jiffy][jiffy], and [jsx][jsx])
+* `map` (**default**)(common to [jsone][jsone], [jiffy][jiffy], and [jsx][jsx])
+* `proplist` (used by [jsonx][jsonx])
 * `eep18` (common to [jiffy][jiffy], [jsone][jsone], and [jsonx][jsonx])
 * `struct` (common to [mochijson2][mochijson2])
 
@@ -27,27 +27,6 @@ need arose for the library to be proplist-compatible, then map-compatible, so
 it has been refactored to be a nearly standalone library.
 
 ## Caveats & known issues
-
-### Deprecated: Erlang 17 or lower
-
-jsn will no longer support Erlang 17 or previous Erlang releases. Allowing the
-`map` format to work without breaking Erlang versions that do not support maps
-(or have an incomplete implementation of maps, i.e., Erlang 17) requires
-inelegant conditional macros throughout the code and test. This support will
-be removed in the next major version of jsn.
-
-### Deprecated: encoding and decoding
-
-jsn will no longer support encoding and decoding. It will be removed in the next
-major version of jsn. See [below](#encode-decode) for more information.
-
-### Deprecated: key sorting functions
-
-jsn will no longer support the `jsn:sort/1`, `jsn:sort_keys/1`, and
-`jsn:sort_equal/2` functions. These functions are incompatible with the `map`
-format; the ambiguity of library functions which are only partially compatible
-with the supported formats is confusing for clients. For this reason, the
-functions will be removed in the next major version of jsn.
 
 ### Proplist format concerns
 
@@ -69,25 +48,9 @@ jsn does not plan to support a [jsx][jsx] and [jsone][jsone] compatible
 format instead. It a vastly more performant data structure that maps naturally
 to JSON objects without ambiguity.
 
-### Edoc generation broken by map support
-
-the `edoc` make target (and using `rebar3 edoc`) are currently broken due to a
-parser problem triggered by the `IF_MAPS(...)` macro used to implement the
-`map` format in a backwards-compatible fashion. Edoc support will be restored
-when this problem is addressed in Erlang or the `map` backwards-compatibility
-constructions are removed from jsn in a future version.
-
 ## Roadmap
 
-### 2.0.0
-
-* **Remove deprecated functions `jsn:sort/1`, `jsn:sort_keys/1`, and `jsn:sort_equal/2`**.
-* **Remove deprecated support for Erlang 17 and lower**. Full `map` support will be
-  assumed by the code, and these older versions will no longer be able to
-  compile jsn.
-* **Make `map` the default object format**. Maps are superior to proplists for
-  JSON object representation in Erlang, and will be favored primarily by the
-  library.
+Future improvements to this library are TBD at this time.
 
 ## Running 
 
@@ -160,8 +123,8 @@ There are 3 different supported path styles, each with different tradeoffs:
 ## Library functions
 
 jsn provides functions to create, append, delete, and transform objects in all
-supported formats (`proplist`, `eep18`, and `struct`). This section contains a
-reference for the primary library functions available.
+supported formats (`map`, `proplist`, `eep18`, and `struct`). This section
+contains a reference for the primary library functions available.
 
 ### `new/0,1,2` - Create a new object
 
@@ -513,18 +476,6 @@ jsn:transform([{key1, T1},{key2, T1},{key4, T1}], NewDestination).
 %  {<<"key1">>,<<"1">>},
 %  {<<"key2">>,<<"2">>}]
 ```
-
-### <a name="encode-decode"></a>`encode/1` and `decode/1,2` - Encoding/decoding JSON for interaction with jsn
-
-**NOTE**: encoding and decoding are **deprecated**, and will be removed in a
-future version of jsn (`2.x.x`). the [jsonx][jsonx] library that jsn uses for
-this functionality is abandoned, and users are strongly advised to use any of
-the many Erlang JSON libraries available:
-
-* [jiffy][jiffy] (`eep18` and `map` formats)
-* [jsone][jsone] (`eep18`, `proplist`, and `map` formats)
-* [jsx][jsx] (`proplist` and `map` formats)
-* [mochijson2][mochijson2] (`struct` format)
 
 ### `equal/3,4` - Path-wise object comparison
 

--- a/erl.sh
+++ b/erl.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-# ex: et sw=4 ts=4
-
-ERL_LIBS=`pwd`/deps erl -config erl -pa ebin -boot start_sasl $*

--- a/include/jsn.hrl
+++ b/include/jsn.hrl
@@ -16,20 +16,12 @@
 -type json_boolean()       :: true | false.
 -type json_null()          :: null.
 -type json_array()         :: [json_term()].
--type json_no_map_array() ::  [json_no_map_term()].
 -type json_array_index()   :: first | last | pos_integer().
+-type json_map()           :: #{json_key() => json_term()}.
 -type json_proplist()      :: [{json_key(), json_term()}].
 -type json_eep18()         :: {json_proplist()}.
 -type json_struct()        :: {struct, json_proplist()}.
--type json_no_map_object() :: json_proplist() | json_eep18() | json_struct().
--ifdef(maps_support).
--type json_map()           :: #{json_key() => json_term()}.
--type json_object()        :: json_no_map_object() | json_map().
--else.
--type json_object()        :: json_no_map_object().
--endif.
--type json_no_map_term()   :: json_string() | json_number() | json_no_map_array() |
-                              json_null()   | json_boolean() | json_no_map_object().
+-type json_object()        :: json_map() |json_proplist() | json_eep18() | json_struct().
 -type json_term()          :: json_string() | json_number() | json_array() |
                               json_null()   | json_boolean() | json_object().
 
@@ -43,11 +35,7 @@
 %% * eep18 (a.k.a EJSON) 
 %% * struct (mochijson2 format)
 %%
--ifdef(maps_support).
 -type format()      :: map | proplist | eep18 | struct.
--else.
--type format()      :: proplist | eep18 | struct.
--endif.
 -type jsn_option()  :: {format, format()}.
 -type jsn_options() :: [ jsn_option() ].
 
@@ -91,11 +79,6 @@
 
 -define(EMPTY_STRUCT, {struct, []}).
 
--ifdef(maps_support).
--define(IF_MAPS(Expr), Expr).
 -define(EMPTY_MAP, #{}).
--else.
--define(IF_MAPS(_), ).
--endif.
 
 -endif.

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,4 @@
-{deps, [{jsonx, {git, "https://github.com/alertlogic/jsonx.git", {branch, master}}}]}.
-
-{erl_opts, [{platform_define, "^1[89]|^[2-9][0-9]+", maps_support},
-            {platform_define, "^1[89]|^[2-9][0-9]+", has_rand},
-            inline_list_funcs,
+{erl_opts, [inline_list_funcs,
             warn_deprecated_function,
             warn_export_vars,
             warn_obsolete_guard,

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,1 @@
-[{<<"jsonx">>,
-  {git,"https://github.com/alertlogic/jsonx.git",
-       {ref,"02ddffb5da9c6d1664bda89b459480b69ebff258"}},
-  0}].
+[].

--- a/src/jsn.app.src
+++ b/src/jsn.app.src
@@ -1,6 +1,6 @@
 {application, jsn, [
     {description, "Utilities for interacting with decoded JSON in erlang"},
-    {vsn, "1.2.1"}, %% <- need to set this appropriately when publishing to hex.pm
+    {vsn, "2.0.0"},
     {applications, [kernel,
                     stdlib,
                     jsonx]},

--- a/src/jsn.app.src
+++ b/src/jsn.app.src
@@ -2,8 +2,8 @@
     {description, "Utilities for interacting with decoded JSON in erlang"},
     {vsn, "2.0.0"},
     {applications, [kernel,
-                    stdlib,
-                    jsonx]},
+                    stdlib
+                   ]},
     {maintainers, ["Nicholas Lundgaard", "Mark Allen"]},
     {licenses, ["Apache 2"]},
     {links, [{"Github", "https://github.com/nalundgaard/jsn"}]}


### PR DESCRIPTION
* New default format: map
* Remove compatibility with Erlang 17 and below.
* Remove encode/decode functionality (no more jsonx dependency)
* Remove key sorting functions