### PR TITLE
Remove jsonx from .app.src

### DIFF
--- a/src/jsn.app.src
+++ b/src/jsn.app.src
@@ -2,8 +2,8 @@
     {description, "Utilities for interacting with decoded JSON in erlang"},
     {vsn, "2.0.0"},
     {applications, [kernel,
-                    stdlib,
-                    jsonx]},
+                    stdlib
+                   ]},
     {maintainers, ["Nicholas Lundgaard", "Mark Allen"]},
     {licenses, ["Apache 2"]},
     {links, [{"Github", "https://github.com/nalundgaard/jsn"}]}


### PR DESCRIPTION
Think we forgot to clear this out when you nuked it from orbit.