### PR TITLE
Delete unneeded rebar.config.script

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Future improvements to this library are TBD at this time.
 
 ## Changelog
 
+18 August 2019 - 2.1.2
+
+* Remove unneeded rebar.config.script ([#31](https://github.com/nalundgaard/jsn/pull/31))
+
 27 February 2018 - 2.1.1
 
 * Resolved #24, jsn:new fails while making an array of objects in struct ( resolved by PR #25)

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,7 +1,0 @@
-case erlang:function_exported(rebar3, main, 1) of
-    true -> % rebar3
-        CONFIG;
-    false -> % rebar 2.x or older
-        NewDeps = {deps, [{jsonx, "", {git, "https://github.com/alertlogic/jsonx.git", {branch, master}}}]},
-        lists:keyreplace(deps, 1, CONFIG, NewDeps)
-end.

--- a/src/jsn.app.src
+++ b/src/jsn.app.src
@@ -1,6 +1,6 @@
 {application, jsn, [
     {description, "Utilities for interacting with decoded JSON in erlang"},
-    {vsn, "2.1.1"},
+    {vsn, "2.1.2"},
     {applications, [kernel,
                     stdlib
                    ]},


### PR DESCRIPTION
This was missed in https://github.com/nalundgaard/jsn/pull/18, much like the jsonx removal from the app.src done in https://github.com/nalundgaard/jsn/pull/19. No deps at all means no need to re-format them.