### PR TITLE
Travis update: Add Erlang/OTP 21 & 22, Update 20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: erlang
 sudo: false
 otp_release:
-  - 20.2
+  - 22.0
+  - 21.3
+  - 20.3
   - 19.3
-  - 18.3
 install: true
 script:
   - ./rebar3 compile 


### PR DESCRIPTION
* Also, remove 18.3. Travis doesn’t seem to keep it anymore.