### PR TITLE
Export 'json_map()' type, remove ifdef(TEST) logic

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
 
 {validate_app_modules, true}.
 
-{profiles, [{test, [{erl_opts, [nowarn_export_all, debug_info]}]}]}.
+{profiles, [{test, [{erl_opts, [export_all, debug_info]}]}]}.
 
 {cover_enabled, true}.
 {cover_opts, [verbose]}.

--- a/src/jsn.erl
+++ b/src/jsn.erl
@@ -34,15 +34,11 @@
 -export([as_map/1, from_map/1, from_map/2,
          as_proplist/1, from_proplist/1, from_proplist/2]).
 
--ifdef(TEST).
--compile([export_all]).
--endif.
-
 %%==============================================================================
 %% types
 %%==============================================================================
 
--export_type([json_proplist/0, json_eep18/0, json_struct/0,
+-export_type([json_map/0, json_proplist/0, json_eep18/0, json_struct/0,
               json_object/0,
               json_term/0,
               path/0, paths/0,

--- a/test/jsn_tests.erl
+++ b/test/jsn_tests.erl
@@ -1,8 +1,6 @@
 
 -module(jsn_tests).
 
--ifdef(TEST).
--compile([export_all]).
 -include_lib("eunit/include/eunit.hrl").
 
 -include("jsn.hrl").
@@ -1149,6 +1147,3 @@ binary_join_test_() ->
     [?_assertEqual(<<"foo bar">>, jsn:binary_join([<<"foo">>,<<"bar">>], <<" ">>)),
      ?_assertEqual(<<"foo">>, jsn:binary_join([<<"foo">>], <<" ">>)),
      ?_assertEqual(<<>>, jsn:binary_join([], <<" ">>))].
-
-
--endif.


### PR DESCRIPTION
* Export `json_map()` from jsn module, consistent with other JSON object format exports.
* Remove `-ifdef(TEST)` logic for compiling with `export_all`; just do this in the `test` profile for succinctness.
* Don't wrap `jsn_tests` in `-ifdef(TEST)` check; it's already isolated from `src` directory and does not need this extra layer of logic.